### PR TITLE
WSNG-319: Ability to accept a robots.txt file io as an argument so check does not have to download the file from the domain

### DIFF
--- a/lib/robots.rb
+++ b/lib/robots.rb
@@ -8,10 +8,14 @@ class Robots
   DEFAULT_TIMEOUT = 3
 
   class ParsedRobots
-
-    def initialize(uri, user_agent, robots_file_io)
+    # We changed the argument list to now take an extra io object of the robots.txt file
+    # Since we don't want to hit the domain to grab the robots.txt file on every request,
+    # we will be caching robots.txt in redis and supplying that here to check if the url is allowed
+    def initialize(uri, user_agent, robots_file_io=nil)
       @last_accessed = Time.at(1)
 
+      # check for the presence of a locally cached robots.txt file io object that is passed in
+      # if it looks valid, then use it, if not do what the gem did before of reaching for it from the domain
       if robots_file_io && robots_file_io.content_type == "text/plain" && robots_file_io.status == ["200", "OK"]
         io = robots_file_io
       else
@@ -120,6 +124,7 @@ class Robots
     @timeout || DEFAULT_TIMEOUT
   end
 
+  # We changed the argument list to now take an extra io object of the robots.txt file
   def initialize(user_agent, robots_file_io=nil)
     @user_agent = user_agent
     @parsed = {}
@@ -129,6 +134,7 @@ class Robots
   def allowed?(uri)
     uri = URI.parse(uri.to_s) unless uri.is_a?(URI)
     host = uri.host
+    # We changed the argument list to now take an extra io object of the robots.txt file
     @parsed[host] ||= ParsedRobots.new(uri, @user_agent, @robots_file_io)
     @parsed[host].allowed?(uri, @user_agent)
   end

--- a/test/test_robots.rb
+++ b/test/test_robots.rb
@@ -6,7 +6,7 @@ module FakeHttp
   def content_type
     "text/plain"
   end
-  
+
   def status
     ["200", "OK"]
   end
@@ -18,59 +18,66 @@ class TestRobots < Test::Unit::TestCase
       fixture_file = File.dirname(__FILE__) + "/fixtures/" + uri.host.split(".")[-2] + ".txt"
       File.open(fixture_file).extend(FakeHttp)
     end
-    
-    @robots = Robots.new "Ruby-Robot.txt Parser Test Script"
+
+    @robots = Robots.new("Ruby-Robot.txt Parser Test Script")
   end
-  
+
   def test_allowed_if_no_robots
     def Robots.get_robots_txt(uri, user_agent)
       return nil
     end
-    
+
     assert_allowed("somesite", "/")
   end
-  
+
   def test_disallow_nothing
     assert_allowed("emptyish", "/")
     assert_allowed("emptyish", "/foo")
   end
-  
+
   def test_reddit
     assert_allowed("reddit", "/")
   end
-  
+
   def test_other
     assert_allowed("yelp", "/foo")
     assert_disallowed("yelp", "/mail?foo=bar")
   end
-  
+
   def test_site_with_disallowed
     assert_allowed("google", "/")
   end
-  
+
   def test_other_values
     sitemap = {"Sitemap" => ["http://www.eventbrite.com/sitemap_index.xml", "http://www.eventbrite.com/sitemap_index.xml"]}
     assert_other_equals("eventbrite", sitemap)
   end
-  
+
   def assert_other_equals(name, value)
     assert_equal(value, @robots.other_values(uri_for_name(name, "/")))
   end
-  
+
   def assert_allowed(name, path)
     assert_allowed_equals(name, path, true)
   end
-  
+
   def assert_disallowed(name, path)
     assert_allowed_equals(name, path, false)
   end
-  
+
   def assert_allowed_equals(name, path, value)
     assert_equal(value, @robots.allowed?(uri_for_name(name, path)), @robots.inspect)
   end
-  
+
   def uri_for_name(name, path)
     uri = name.nil? ? nil : "http://www.#{name}.com#{path}"
   end
-    
+
+  def test_robots_file_provided
+    fixture_file = File.dirname(__FILE__) + "/fixtures/eventbrite.txt"
+    io = File.open(fixture_file).extend(FakeHttp)
+    @robots = Robots.new("Ruby-Robot.txt Parser Test Script", io)
+
+    assert_allowed("eventbrite", "/signin/")
+  end
 end


### PR DESCRIPTION
- Addresses  part of the JIRA ticket WSNG-319
- WPP PR: https://github.com/cobroventures/web_page_processor/pull/416 will utilize this change